### PR TITLE
re-introduce Grafter and rewrite graphs using singleton strategy.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ val dependencies = Seq(
   "org.typelevel"              %% "cats"                       % "0.9.0",
   "ch.qos.logback"              % "logback-classic"            % "1.2.3"      % Runtime,
   "com.github.pureconfig"      %% "pureconfig"                 % "0.7.2",
+  "org.zalando"                %% "grafter"                    % "2.1.1",
 
   "io.kamon"                   %% "kamon-jmx"                  % kamonVersion,
   "io.kamon"                   %% "kamon-akka-2.5"             % kamonVersion,

--- a/scheduler/src/main/scala/com/sky/kms/Main.scala
+++ b/scheduler/src/main/scala/com/sky/kms/Main.scala
@@ -15,7 +15,7 @@ object Main extends App with LazyLogging with AkkaComponents {
 
   val app = SchedulerApp.configure apply conf
 
-  val runningApp = SchedulerApp.run apply app
+  val runningApp = SchedulerApp.run apply app value
 
   sys.addShutdownHook {
     logger.info("Kafka Message Scheduler shutting down...")

--- a/scheduler/src/main/scala/com/sky/kms/SchedulerApp.scala
+++ b/scheduler/src/main/scala/com/sky/kms/SchedulerApp.scala
@@ -6,6 +6,7 @@ import cats.implicits.catsStdInstancesForFuture
 import com.sky.kms.config.Configured
 import com.sky.kms.streams.{ScheduleReader, ScheduledMessagePublisher}
 import kamon.Kamon
+import org.zalando.grafter.Rewriter._
 
 import scala.concurrent.ExecutionContext
 
@@ -15,19 +16,20 @@ object SchedulerApp {
 
   case class Running(runningReader: ScheduleReader.Mat, runningPublisher: ScheduledMessagePublisher.Mat)
 
-  def configure(implicit system: ActorSystem): Configured[SchedulerApp] =
+  def configure(implicit system: ActorSystem): Configured[SchedulerApp] = {
     for {
       scheduleReader <- ScheduleReader.configure
       publisher <- ScheduledMessagePublisher.configure
     } yield SchedulerApp(scheduleReader, publisher)
+  }.singletons
 
   def run(implicit system: ActorSystem, mat: ActorMaterializer): Start[Running] = {
     Kamon.start()
     for {
       runningPublisher <- ScheduledMessagePublisher.run
-      runningReader <- ScheduleReader.run(runningPublisher)
+      runningReader <- ScheduleReader.run
     } yield Running(runningReader, runningPublisher)
-  }
+  }.singletons
 
   def stop(implicit ec: ExecutionContext): Stop[Unit] =
     for {

--- a/scheduler/src/main/scala/com/sky/kms/package.scala
+++ b/scheduler/src/main/scala/com/sky/kms/package.scala
@@ -1,7 +1,8 @@
 package com.sky
 
-import cats.data.{Kleisli, Reader, ReaderT}
+import cats.data.{Kleisli, ReaderT}
 import cats.syntax.either._
+import cats.{Eval, Later}
 import com.sksamuel.avro4s.AvroInputStream
 import com.sky.kms.avro._
 import com.sky.kms.domain.ApplicationError._
@@ -35,7 +36,11 @@ package object kms extends LazyLogging {
   private def valueDecoder(avro: Array[Byte]): Option[Try[Schedule]] =
     AvroInputStream.binary[Schedule](avro).tryIterator.toSeq.headOption
 
-  type Start[T] = Reader[SchedulerApp, T]
+  type Start[T] = ReaderT[Eval, SchedulerApp, T]
+
+  object Start {
+    def apply[T](f: SchedulerApp => T): Start[T] = Kleisli(f andThen (Eval.later(_)))
+  }
 
   type Stop[T] = ReaderT[Future, SchedulerApp.Running, T]
 

--- a/scheduler/src/main/scala/com/sky/kms/streams/ScheduledMessagePublisher.scala
+++ b/scheduler/src/main/scala/com/sky/kms/streams/ScheduledMessagePublisher.scala
@@ -4,7 +4,6 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.scaladsl._
 import akka.stream.{ActorMaterializer, OverflowStrategy}
-import cats.data.Reader
 import com.sky.kms.config._
 import com.sky.kms.domain.PublishableMessage._
 import com.sky.kms.domain._
@@ -48,7 +47,7 @@ object ScheduledMessagePublisher {
     SchedulerConfig.reader.map(ScheduledMessagePublisher(_, KafkaStream.sink))
 
   def run(implicit mat: ActorMaterializer): Start[Mat] =
-    Reader(_.scheduledMessagePublisher.stream.run())
+    Start(_.scheduledMessagePublisher.stream.run())
 
   def stop: Stop[Done] =
     Stop { app =>

--- a/scheduler/src/test/scala/com/sky/kms/e2e/SchedulerIntSpec.scala
+++ b/scheduler/src/test/scala/com/sky/kms/e2e/SchedulerIntSpec.scala
@@ -39,7 +39,7 @@ class SchedulerIntSpec extends SchedulerIntBaseSpec {
 
   private def withRunningSchedulerStream(scenario: => Assertion) {
     val app = SchedulerApp.configure apply AppConfig(conf)
-    val runningApp = SchedulerApp.run apply app
+    val runningApp = SchedulerApp.run apply app value
 
     scenario
 


### PR DESCRIPTION
Make all instances of `Start` lazy so we can rewrite the graph using the singletons strategy (make sure there is only ever one instance of any component) before we actually evaluate the start functions.