### PR TITLE
Log a warning if there is a problem putting a schedule on the publisher queue

### DIFF
--- a/scheduler/src/main/scala/com/sky/kms/SchedulingActor.scala
+++ b/scheduler/src/main/scala/com/sky/kms/SchedulingActor.scala
@@ -13,7 +13,7 @@ import com.sky.kms.domain._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.FiniteDuration
 
-class SchedulingActor(queue: SourceQueue[(String, ScheduledMessage)], akkaScheduler: Scheduler) extends Actor with ActorLogging {
+class SchedulingActor(publisher: SourceQueue[(String, ScheduledMessage)], akkaScheduler: Scheduler) extends Actor with ActorLogging {
 
   override def receive: Receive = waitForInit
 
@@ -52,11 +52,10 @@ class SchedulingActor(queue: SourceQueue[(String, ScheduledMessage)], akkaSchedu
 
   private val handleTrigger: Receive = {
     case Trigger(scheduleId, schedule) =>
-      log.info(s"$scheduleId is due. Adding schedule to queue. Scheduled time was ${schedule.time}")
-      queue.offer((scheduleId, messageFrom(schedule))).failed.foreach { error =>
-        log.warning(s"Could not add schedule $scheduleId to queue. Queue returned error: ${error.getMessage}")
+      log.info(s"$scheduleId is due. Adding schedule to the publisher. Scheduled time was ${schedule.time}")
+      publisher.offer((scheduleId, messageFrom(schedule))).failed.foreach { error =>
+        log.warning(s"Could not add schedule $scheduleId to the publisher. Publisher returned error: ${error.getMessage}")
       }
-
   }
 
   private def cancel(scheduleId: ScheduleId, schedules: Map[ScheduleId, Cancellable]): Boolean =

--- a/scheduler/src/test/scala/com/sky/kms/unit/SchedulingActorSpec.scala
+++ b/scheduler/src/test/scala/com/sky/kms/unit/SchedulingActorSpec.scala
@@ -86,7 +86,7 @@ class SchedulingActorSpec extends AkkaBaseSpec with ImplicitSender with MockitoS
       advanceToTimeFrom(schedule, now)
 
       eventually {
-        verify(mockLogger).warning(s"Could not add schedule $scheduleId to queue. Queue returned error: bad")
+        verify(mockLogger).warning(s"Could not add schedule $scheduleId to the publisher. Publisher returned error: bad")
       }
     }
 


### PR DESCRIPTION
Currently we ignore the result of adding a schedule to the publisher. In this PR a warning message has been added so we can see if something is wrong.