### PR TITLE
add clean step in release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,6 @@ lazy val dockerSettings = Seq(
     Cmd("USER", "root"),
     Cmd("RUN", "apk update && apk add bash")
   ),
-  dockerBuildOptions += "--no-cache",
   dockerExposedPorts in Docker := Seq(jmxPort)
 )
 


### PR DESCRIPTION
When releasing since the previous PR it became apparent that the fix hadn't been released, after removing the image I had locally and then adding these options and rebuilding - it seemed to work.

I pushed to docker hub, overwriting the previously released version `0.7.0` again after this to make sure `0.7.0` works as expected. I might do this a few more times just to make sure this does actually fix the problem.

I haven't been able to replicate the issue since this change so hopefully all is good now. Seems like a good thing to do either way.