### PR TITLE
Add configuration overrides for default prometheus buckets

### DIFF
--- a/scheduler/src/main/resources/application.conf
+++ b/scheduler/src/main/resources/application.conf
@@ -79,10 +79,18 @@ kamon {
 
   akka.actor-groups = ["kms-actors"]
   reporters = ["kamon.prometheus.PrometheusReporter"]
-  prometheus.embedded-server {
-    hostname = 0.0.0.0
-    port = 9095
-    port = ${?PROMETHEUS_SCRAPING_ENDPOINT_PORT}
+  prometheus {
+    buckets {
+      default-buckets = ${?PROMETHEUS_DEFAULT_BUCKETS}
+      time-buckets = ${?PROMETHEUS_TIME_BUCKETS}
+      information-buckets = ${?PROMETHEUS_INFORMATION_BUCKETS}
+    }
+
+    embedded-server {
+      hostname = 0.0.0.0
+      port = 9095
+      port = ${?PROMETHEUS_SCRAPING_ENDPOINT_PORT}
+    }
   }
   system-metrics.host.enabled = false
 }


### PR DESCRIPTION
The default kamon prometheus information-buckets range from 512 bytes to 1mb. This isn't very helpful when trying to get metrics for a 2gb app. Also added optional overrides for default and time buckets in case customisation is required later on.