### PR TITLE
use Zulu time encoding in logstash messages

### DIFF
--- a/scheduler/src/main/resources/logback.xml
+++ b/scheduler/src/main/resources/logback.xml
@@ -2,7 +2,21 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <if condition='isDefined("KMS_LOGGING_LOGSTASH")'>
             <then>
-                <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+                <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                    <providers>
+                        <timestamp>
+                            <timeZone>Zulu</timeZone>
+                            <pattern>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</pattern>
+                        </timestamp>
+                        <threadName/>
+                        <program/>
+                        <loggerName/>
+                        <logLevel/>
+                        <message/>
+                        <stackTrace/>
+                        <arguments/>
+                    </providers>
+                </encoder>
             </then>
             <else>
                 <encoder>


### PR DESCRIPTION
Our kibana is showing two timestamp values. 

[our-dev-kibana](http://es.dev.cosmic.sky/_plugin/kibana/app/kibana#/discover?_g=()&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logs-dev-*',key:kubernetes.namespace_name,negate:!f,type:phrase,value:aj-stubbed-showcase),query:(match:(kubernetes.namespace_name:(query:aj-stubbed-showcase,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logs-dev-*',key:kubernetes.labels.app,negate:!f,type:phrase,value:kafka-scheduler),query:(match:(kubernetes.labels.app:(query:kafka-scheduler,type:phrase))))),index:'logs-dev-*',interval:auto,query:(match_all:()),sort:!('@timestamp',desc)))

This happens becase we log a record with a `@timestamp` field with a timezone offset:
```"@timestamp": "2018-07-06T10:55:04.998+00:00"```
The expected format for ES is with the Zulu time zone abbreviation:
```"@timestamp": "2018-07-06T10:55:04.998Z"```
Because they are basically equivalent, we allow the value instead of rejecting the record. ES considers them to be different values so, instead of using the provided value, it generates its own. It then returns two values for the same field when queried.

![screen shot 2018-07-20 at 18 39 12](https://user-images.githubusercontent.com/676844/43016937-67a2ce46-8c4c-11e8-939a-a50f7ca35a7b.png)

