### PR TITLE
remove misleading log

### DIFF
--- a/scheduler/src/main/scala/com/sky/kms/streams/ScheduleReader.scala
+++ b/scheduler/src/main/scala/com/sky/kms/streams/ScheduleReader.scala
@@ -44,10 +44,8 @@ object ScheduleReader extends LazyLogging {
     readResult.map { case (scheduleId, scheduleOpt) =>
       scheduleOpt match {
         case Some(schedule) =>
-          logger.info(s"Publishing scheduled message with ID: $scheduleId to topic: ${schedule.topic}")
           CreateOrUpdate(scheduleId, schedule)
         case None =>
-          logger.info(s"Cancelling schedule $scheduleId")
           Cancel(scheduleId)
       }
     }


### PR DESCRIPTION
Closes #44 

Remove logs from reader stream as we log what we need in the scheduling actor anyway.