### PR TITLE
Upgraded to new version of Akka Kafka for Kafka 1.1.0 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val dependencies = Seq(
   "com.typesafe.akka"          %% "akka-actor"                 % akkaVersion,
   "com.typesafe.akka"          %% "akka-stream"                % akkaVersion,
   "com.typesafe.akka"          %% "akka-slf4j"                 % akkaVersion,
-  "com.typesafe.akka"          %% "akka-stream-kafka"          % "0.19",
+  "com.typesafe.akka"          %% "akka-stream-kafka"          % "0.22",
   "com.typesafe.akka"          %% "akka-stream-contrib"        % "0.8",
   "io.monix"                   %% "monix-execution"            % "3.0.0-RC1",
 

--- a/scheduler/src/test/scala/com/sky/kms/e2e/SchedulerResiliencySpec.scala
+++ b/scheduler/src/test/scala/com/sky/kms/e2e/SchedulerResiliencySpec.scala
@@ -19,6 +19,7 @@ import com.sky.kms.config.{AppConfig, SchedulerConfig}
 import com.sky.kms.domain.ScheduleEvent
 import com.sky.kms.streams.{ScheduleReader, ScheduledMessagePublisher}
 import com.sky.kms.{AkkaComponents, SchedulerApp}
+import org.apache.kafka.common.{Metric, MetricName}
 import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 
@@ -115,6 +116,8 @@ class SchedulerResiliencySpec extends BaseSpec with ScalaFutures {
     override def shutdown() = Future(Done)
 
     override def isShutdown = Future(Done)
+
+    override def metrics: Future[Map[MetricName, Metric]] = Future(Map.empty)
   }
 
   private trait FailingSource {


### PR DESCRIPTION
We require a metric specifically from Kafka 1.0.0 for verification purposes `record-send-total`, this requires an upgrade of Akka Streams Kafka.