### PR TITLE
Fixes a flaky test in ScheduleReaderIntSpec

### DIFF
--- a/scheduler/src/test/scala/com/sky/kms/e2e/ScheduleReaderIntSpec.scala
+++ b/scheduler/src/test/scala/com/sky/kms/e2e/ScheduleReaderIntSpec.scala
@@ -2,6 +2,7 @@ package com.sky.kms.e2e
 
 import java.util.UUID
 
+import akka.kafka.ConsumerSettings
 import akka.stream.scaladsl.Sink
 import akka.testkit.{TestActor, TestProbe}
 import com.sky.kms.BackoffRestartStrategy
@@ -16,12 +17,17 @@ import com.sky.kms.streams.ScheduleReader
 import com.sky.kms.utils.TestActorSystem
 import eu.timepit.refined.auto._
 import net.manub.embeddedkafka.Codecs.{stringSerializer, nullSerializer => arrayByteSerializer}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.scalatest.Assertion
+import org.scalatest.concurrent.Eventually
 
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
-class ScheduleReaderIntSpec extends SchedulerIntSpecBase {
+class ScheduleReaderIntSpec extends SchedulerIntSpecBase with Eventually {
 
-  override implicit lazy val system = TestActorSystem(kafkaConfig.kafkaPort, maxWakeups = 3, wakeupTimeout = 3.seconds, akkaExpectDuration = 15.seconds)
+  override implicit lazy val system = TestActorSystem(kafkaConfig.kafkaPort, maxWakeups = 3, wakeupTimeout = 3.seconds, akkaExpectDuration = 20.seconds)
 
   val numSchedules = 3
 
@@ -34,6 +40,10 @@ class ScheduleReaderIntSpec extends SchedulerIntSpecBase {
         writeSchedulesToKafka(firstSchedule)
 
         probe.expectMsgType[CreateOrUpdate].scheduleId shouldBe firstSchedule._1
+
+        eventually {
+          offsetShouldBeCommitted
+        }
       }
 
       withRunningScheduleReader { probe =>
@@ -83,6 +93,13 @@ class ScheduleReaderIntSpec extends SchedulerIntSpecBase {
     } finally {
       killSwitch.shutdown()
     }
+  }
+
+  private def offsetShouldBeCommitted: Assertion = {
+    val consumer = ConsumerSettings(system, new ByteArrayDeserializer, new ByteArrayDeserializer).createKafkaConsumer()
+    val partition = new TopicPartition(scheduleTopic, 0)
+    consumer.assign(List(partition).asJava)
+    consumer.position(partition) should be > 0l
   }
 
   private def writeSchedulesToKafka(schedules: (ScheduleId, ScheduleEvent)*): Unit =


### PR DESCRIPTION
ensure offset is committed before terminating reader stream in reader int spec, since the test relies on the offset being committed