### PR TITLE
log level for com.sky logs

### DIFF
--- a/scheduler/src/main/resources/logback.xml
+++ b/scheduler/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
         </if>
     </appender>
 
-    <logger name="com.sky.kms" level="${KMS_LOGGING_LEVEL:-INFO}" additivity="false">
+    <logger name="com.sky" level="${KMS_LOGGING_LEVEL:-INFO}" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 


### PR DESCRIPTION
we weren't seeing the logs from the kafka-topic-loader since it doesn't fall under com.sky.kms