### PR TITLE
use finite duration instead of akka timeout in config

### DIFF
--- a/scheduler/src/main/scala/com/sky/kms/config/config.scala
+++ b/scheduler/src/main/scala/com/sky/kms/config/config.scala
@@ -1,6 +1,5 @@
 package com.sky.kms.config
 
-import akka.util.Timeout
 import cats.data.{NonEmptyList, Reader}
 import com.sky.kms.kafka.Topic
 import com.sky.map.commons.akka.streams.BackoffRestartStrategy
@@ -20,12 +19,12 @@ object SchedulerConfig {
 case class ReaderConfig(scheduleTopics: NonEmptyList[Topic],
                         restartStrategy: BackoffRestartStrategy,
                         offsetBatch: OffsetBatchConfig,
-                        timeouts: ReaderConfig.Timeouts)
+                        timeouts: ReaderConfig.TimeoutConfig)
 
 object ReaderConfig {
   def configure: Configured[ReaderConfig] = SchedulerConfig.configure.map(_.reader)
 
-  case class Timeouts(scheduling: Timeout, initialisation: Timeout)
+  case class TimeoutConfig(scheduling: FiniteDuration, initialisation: FiniteDuration)
 }
 
 case class OffsetBatchConfig(commitBatchSize: Int Refined Positive, maxCommitWait: FiniteDuration)

--- a/scheduler/src/main/scala/com/sky/kms/streams/ScheduleReader.scala
+++ b/scheduler/src/main/scala/com/sky/kms/streams/ScheduleReader.scala
@@ -38,7 +38,7 @@ case class ScheduleReader[F[_] : Traverse : Comonad](loadProcessedSchedules: Loa
                                                      commit: Flow[F[Either[ApplicationError, Ack.type]], Done, NotUsed],
                                                      errorHandler: Sink[ApplicationError, Future[Done]],
                                                      restartStrategy: BackoffRestartStrategy,
-                                                     timeouts: ReaderConfig.Timeouts)(
+                                                     timeouts: ReaderConfig.TimeoutConfig)(
                                                       implicit system: ActorSystem) {
 
   import system.dispatcher

--- a/scheduler/src/test/scala/com/sky/kms/unit/ScheduleReaderSpec.scala
+++ b/scheduler/src/test/scala/com/sky/kms/unit/ScheduleReaderSpec.scala
@@ -130,7 +130,7 @@ class ScheduleReaderSpec extends AkkaStreamSpecBase with Eventually {
         Flow[Either[ApplicationError, Ack.type]].map(_ => Done),
         errorHandler,
         numRestarts,
-        ReaderConfig.Timeouts(100.millis, 100.millis)).stream.runWith(Sink.ignore)
+        ReaderConfig.TimeoutConfig(100.millis, 100.millis)).stream.runWith(Sink.ignore)
   }
 
   private trait ErrorHandler {

--- a/scheduler/src/test/scala/com/sky/kms/utils/TestConfig.scala
+++ b/scheduler/src/test/scala/com/sky/kms/utils/TestConfig.scala
@@ -14,7 +14,7 @@ object TestConfig {
         topics,
         TestDataUtils.NoRestarts,
         OffsetBatchConfig(1, 1.milli),
-        timeouts = ReaderConfig.Timeouts(100.millis, 100.millis)),
+        timeouts = ReaderConfig.TimeoutConfig(100.millis, 100.millis)),
       PublisherConfig(queueBufferSize = 100),
     )
 }


### PR DESCRIPTION
Pureconfig doesn't know how to parse `akka.util.Timeout` unless you use [this](https://github.com/pureconfig/pureconfig/tree/master/modules/akka) but IMO the config should just be `FiniteDuration` anyway. `akka.util.Timeout` has an implicit conversion for going from `FiniteDuration` to `akka.util.Timeout`