### PR TITLE
Adding glibc so that libraries can be dyanamically loaded 

### DIFF
--- a/project/DockerPublish.scala
+++ b/project/DockerPublish.scala
@@ -21,7 +21,7 @@ object DockerPublish {
     dockerUpdateLatest   := true,
     dockerCommands ++= Seq(
       Cmd("USER", "root"),
-      Cmd("RUN", "apk add --no-cache bash openjdk17")
+      Cmd("RUN", "apk add --no-cache bash openjdk17 libc6-compat")
     )
   )
 


### PR DESCRIPTION
When performing decompression in the kms consumer a library was missing which was needed causing java.lang.UnsatisfiedLinkError as mentioned in #92. 

We was hoping this fix could be added to the base image please.