### PR TITLE
Upgrade alpine and java versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,13 +54,13 @@ val commonSettings = Seq(
 
 lazy val dockerSettings = Seq(
   packageName in Docker := "kafka-message-scheduler",
-  dockerBaseImage := "openjdk:8u171-jre-alpine",
+  dockerBaseImage := "alpine:3.13.2",
   dockerRepository := Some("skyuk"),
   dockerLabels := Map("maintainer" -> "Sky"),
   dockerUpdateLatest := true,
   dockerCommands ++= Seq(
     Cmd("USER", "root"),
-    Cmd("RUN", "apk update && apk add bash eudev")
+    Cmd("RUN", "apk add --no-cache bash eudev openjdk11-jre")
   )
 )
 


### PR DESCRIPTION
Upgrade docker base image to newer version of alpine.
Upgrade Java to 11 from 8.

This change will enforce the removal of old Java 8 container memory flags:

```
-XX:+UnlockExperimentalVMOptions
-XX:+UseCGroupMemoryLimitForHeap
```