### PR TITLE
Improve error message and logging config

### DIFF
--- a/scheduler/src/main/resources/logback.xml
+++ b/scheduler/src/main/resources/logback.xml
@@ -16,6 +16,8 @@
         <appender-ref ref="STDOUT" />
     </logger>
 
+    <logger name="org.apache.kafka.common.metrics" level="OFF" additivity="false" />
+
     <root level="${KMS_ROOT_LOGGING_LEVEL:-WARN}">
         <appender-ref ref="STDOUT" />
     </root>

--- a/scheduler/src/main/scala/com/sky/kms/domain/ApplicationError.scala
+++ b/scheduler/src/main/scala/com/sky/kms/domain/ApplicationError.scala
@@ -25,7 +25,8 @@ object ApplicationError extends LazyLogging {
     case error: InvalidSchemaError     => s"Invalid schema used to produce message with key ${error.key}"
     case error: AvroMessageFormatError =>
       s"Error when processing message with key ${error.key}. ${error.cause.getMessage}"
-    case error: InvalidTimeError       => s"Time between now and ${error.time} is not within 292 years"
+    case error: InvalidTimeError       =>
+      s"Time between now and ${error.time} is not within 292 years on message ${error.key}"
   }
 
   def extractError[T]: Flow[Either[ApplicationError, T], ApplicationError, NotUsed] =


### PR DESCRIPTION
## Description

1. Logger for kafka metrics turned off to avoid this erroneous log:

```
{"@timestamp":"2023-02-09T09:48:59.997Z","@version":"1","message":"Error getting JMX attribute 'records-lag-avg'","logger_name":"org.apache.kafka.common.metrics.JmxReporter", ...
```

2. Add key to invalid time error message to trace Kafka message