### PR TITLE
Revert base image back to Alpine with Temurin JRE

### DIFF
--- a/project/DockerPublish.scala
+++ b/project/DockerPublish.scala
@@ -1,7 +1,8 @@
 import com.typesafe.sbt.packager.Keys._
+import com.typesafe.sbt.packager.docker.Cmd
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.Docker
-import sbt._
 import sbt.Keys._
+import sbt._
 
 import scala.sys.process.Process
 
@@ -14,10 +15,14 @@ object DockerPublish {
 
   private lazy val imageSettings = Seq(
     Docker / packageName := "kafka-message-scheduler",
-    dockerBaseImage      := "eclipse-temurin:17-jre-jammy",
+    dockerBaseImage      := "alpine:3.17.2",
     dockerRepository     := Some("skyuk"),
     dockerLabels         := Map("maintainer" -> "Sky"),
-    dockerUpdateLatest   := true
+    dockerUpdateLatest   := true,
+    dockerCommands ++= Seq(
+      Cmd("USER", "root"),
+      Cmd("RUN", "apk add --no-cache bash openjdk17")
+    )
   )
 
   private lazy val dockerBuildxSettings = Seq(

--- a/project/DockerPublish.scala
+++ b/project/DockerPublish.scala
@@ -21,7 +21,12 @@ object DockerPublish {
     dockerUpdateLatest   := true,
     dockerCommands ++= Seq(
       Cmd("USER", "root"),
-      Cmd("RUN", "apk add --no-cache bash openjdk17")
+      Cmd(
+        "RUN",
+        "wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk"
+      ),
+      Cmd("RUN", "echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories"),
+      Cmd("RUN", "apk add --no-cache bash temurin-17-jre")
     )
   )
 


### PR DESCRIPTION
# Related issues

- See #212

This base image has been tested in https://github.com/sky-uk/kafka-message-scheduler/pull/140 and works in Travis unlike the previous image.

Image size difference:
- Old - 353MB
- New - 238MB (-115MB)

Temurin Alpine install instructions [here](https://adoptium.net/installation/linux/)