### PR TITLE
Use openJDK as Temurin doesn't support ARM alpine

### DIFF
--- a/project/DockerPublish.scala
+++ b/project/DockerPublish.scala
@@ -21,12 +21,7 @@ object DockerPublish {
     dockerUpdateLatest   := true,
     dockerCommands ++= Seq(
       Cmd("USER", "root"),
-      Cmd(
-        "RUN",
-        "wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk"
-      ),
-      Cmd("RUN", "echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories"),
-      Cmd("RUN", "apk add --no-cache bash temurin-17-jre")
+      Cmd("RUN", "apk add --no-cache bash openjdk17")
     )
   )
 


### PR DESCRIPTION
## Description

Modification of https://github.com/sky-uk/kafka-message-scheduler/pull/213

Temurin doesn't have an Alpine package. Reverting back to openJDK