### PR TITLE
Increase resiliency of Integration tests

### DIFF
--- a/scheduler/src/test/scala/com/sky/kms/integration/ScheduleReaderIntSpec.scala
+++ b/scheduler/src/test/scala/com/sky/kms/integration/ScheduleReaderIntSpec.scala
@@ -1,6 +1,7 @@
 package com.sky.kms.integration
 
 import java.util.UUID
+
 import akka.actor.ActorSystem
 import akka.testkit.{TestActor, TestProbe}
 import cats.syntax.functor._

--- a/scheduler/src/test/scala/com/sky/kms/integration/ScheduleReaderIntSpec.scala
+++ b/scheduler/src/test/scala/com/sky/kms/integration/ScheduleReaderIntSpec.scala
@@ -28,12 +28,10 @@ class ScheduleReaderIntSpec extends SchedulerIntSpecBase {
   "stream" should {
     "continue processing when Kafka becomes available" in withRunningScheduleReader { probe =>
       withRunningKafka {
-        probe.expectMsg(StreamStarted)
-        probe.expectMsg(Initialised)
+        probe.expectMsg(5.seconds, StreamStarted)
+        probe.expectMsg(5.seconds, Initialised)
         scheduleShouldFlow(probe)
       }
-      // Wait 5 seconds. Embedded Kafka causes issues if you restart too quickly on the same ports.
-      Thread.sleep(5000)
       withRunningKafka {
         scheduleShouldFlow(probe)
       }

--- a/scheduler/src/test/scala/com/sky/kms/integration/ScheduleReaderIntSpec.scala
+++ b/scheduler/src/test/scala/com/sky/kms/integration/ScheduleReaderIntSpec.scala
@@ -1,7 +1,6 @@
 package com.sky.kms.integration
 
 import java.util.UUID
-
 import akka.actor.ActorSystem
 import akka.testkit.{TestActor, TestProbe}
 import cats.syntax.functor._
@@ -14,30 +13,42 @@ import com.sky.kms.utils.TestActorSystem
 import com.sky.kms.utils.TestDataUtils._
 import eu.timepit.refined.auto._
 import io.github.embeddedkafka.Codecs.{nullSerializer => arrayByteSerializer, stringSerializer}
+import io.github.embeddedkafka.EmbeddedKafka
+import org.scalatest.BeforeAndAfterEach
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class ScheduleReaderIntSpec extends SchedulerIntSpecBase {
+class ScheduleReaderIntSpec extends SchedulerIntSpecBase with BeforeAndAfterEach {
 
   override implicit lazy val system: ActorSystem =
     TestActorSystem(kafkaConfig.kafkaPort, akkaExpectDuration = 20.seconds)
 
   val numSchedules = 3
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    EmbeddedKafka.start()
+  }
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    EmbeddedKafka.stop()
+  }
+
   "stream" should {
     "continue processing when Kafka becomes available" in withRunningScheduleReader { probe =>
-      withRunningKafka {
-        probe.expectMsg(5.seconds, StreamStarted)
-        probe.expectMsg(5.seconds, Initialised)
-        scheduleShouldFlow(probe)
-      }
-      withRunningKafka {
-        scheduleShouldFlow(probe)
-      }
+      probe.expectMsg(StreamStarted)
+      probe.expectMsg(Initialised)
+      scheduleShouldFlow(probe)
+
+      EmbeddedKafka.stop()
+      EmbeddedKafka.start()
+
+      scheduleShouldFlow(probe)
     }
 
-    "not schedule messages that have been deleted but not compacted on startup" in withRunningKafka {
+    "not schedule messages that have been deleted but not compacted on startup" in {
       val schedules @ firstSchedule :: _ = List.fill(numSchedules)(generateSchedule)
       writeSchedulesToKafka(schedules: _*)
       deleteSchedulesInKafka(firstSchedule)


### PR DESCRIPTION
## Description

Integration test was failing because we were starting Kafka before enough time passed to assert Initialised.

Starting Kafka before the tests then restarting it during means we are testing the restartability of the component properly.

## Technical details

ran `test;test;test;test;test;test;test;test;test;test;test;` and all passed. before it was about 50/50