### PR TITLE
Adding bibcd.yml for internal Sky pipeline config

### DIFF
--- a/bibcd.yml
+++ b/bibcd.yml
@@ -1,0 +1,20 @@
+version: 1
+context: map
+tenant: prs-map
+triggering: master-and-prs
+
+modules:
+
+  kafka-message-scheduler:
+    directory: /scheduler
+    pipelineShape: buildOnly
+    serviceName: MetadataAssemblyPipeline
+    additionalSourceDirectories:
+      - /project
+
+defaultTaskExecution: './sbt ${module}-${phase}'
+
+defaultNodes:
+  prBuild: l-asdf
+  cdBuild: l-asdf
+  cdStubbedNft: asdf-nft-agent


### PR DESCRIPTION
- Connects to https://github.com/sky-uk/kafka-message-scheduler/issues/387

Adding a yml file used by internal company tooling used to run automated pipelines, until such time that we're able to replace our existing Travis solution which doesn't work any more.