### PR TITLE
Revert "Cleanup Docker settings"

### DIFF
--- a/project/DockerComposeSettings.scala
+++ b/project/DockerComposeSettings.scala
@@ -1,23 +1,23 @@
-import DockerPublish.registry
 import com.tapad.docker.DockerComposePlugin.autoImport.variablesForSubstitution
-import sbt.Def
+import DockerPublish.allRegistries
 
 import java.net.ServerSocket
-import scala.util.Using
 
 object DockerComposeSettings {
 
-  def freePort: Int =
-    Using.resource(new ServerSocket(0)) { socket =>
-      socket.setReuseAddress(true)
-      socket.getLocalPort
-    }
+  val freePort: Int = {
+    val socket = new ServerSocket(0)
+    socket.setReuseAddress(true)
+    val port   = socket.getLocalPort
+    socket.close()
+    port
+  }
 
-  lazy val kafkaPort: (String, String) = "KAFKA_PORT" -> freePort.toString
+  val kafkaPort = "KAFKA_PORT" -> freePort.toString
 
-  lazy val settings: Seq[Def.Setting[?]] = Seq(
+  lazy val settings = Seq(
     variablesForSubstitution ++= Map(
-      "CONTAINER_REPOSITORY" -> registry,
+      "CONTAINER_REPOSITORY" -> allRegistries.head,
       kafkaPort
     )
   )

--- a/project/DockerPublish.scala
+++ b/project/DockerPublish.scala
@@ -1,19 +1,24 @@
 import com.typesafe.sbt.packager.Keys.*
 import com.typesafe.sbt.packager.docker.Cmd
-import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.{dockerBuildxPlatforms, Docker}
+import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.Docker
+import sbt.Keys.*
 import sbt.*
+
+import scala.sys.process.Process
 
 object DockerPublish {
 
-  lazy val dockerSettings: Seq[Def.Setting[?]] = imageSettings
+  lazy val dockerSettings = imageSettings ++ dockerBuildxSettings
+
+  lazy val ensureDockerBuildx    = taskKey[Unit]("Ensure that docker buildx configuration exists")
+  lazy val dockerBuildWithBuildx = taskKey[Unit]("Build docker images using buildx")
 
   private lazy val imageSettings = Seq(
-    Docker / packageName  := "kafka-message-scheduler",
-    dockerBaseImage       := "alpine:3.21",
-    dockerRepository      := Some(registry),
-    dockerLabels          := Map("maintainer" -> "Sky"),
-    dockerUpdateLatest    := true,
-    dockerBuildxPlatforms := Seq("linux/arm64", "linux/amd64"),
+    Docker / packageName := "kafka-message-scheduler",
+    dockerBaseImage      := "alpine:3.21",
+    dockerRepository     := registry,
+    dockerLabels         := Map("maintainer" -> "Sky"),
+    dockerUpdateLatest   := true,
     dockerCommands ++= Seq(
       Cmd("USER", "root"),
       Cmd("RUN", "apk add --no-cache bash openjdk17")
@@ -21,9 +26,35 @@ object DockerPublish {
     dockerAliases ++= additionalRegistries.map(host => dockerAlias.value.withRegistryHost(Some(host)))
   )
 
-  lazy val allRegistries: List[String]      = sys.env.get("CONTAINER_REPOSITORIES").fold(List("test"))(_.split(" ").toList)
-  lazy val (registry, additionalRegistries) = allRegistries match {
-    case registry :: additionalRegistries => registry -> additionalRegistries
-    case other                            => sys.error("Expected at least one Docker registry")
-  }
+  val allRegistries                     = sys.env.get("CONTAINER_REPOSITORIES").fold(List("test"))(_.split(" ").toList)
+  val registry                          = allRegistries.headOption // Provide a docker registry host
+  val additionalRegistries              = allRegistries.drop(1)    // Remove the first host, because it is already provide.
+  private lazy val dockerBuildxSettings = Seq(
+    ensureDockerBuildx    := {
+      if (Process("docker buildx inspect multi-arch-builder").! == 1) {
+        Process("docker context create multi-arch-context", baseDirectory.value).!
+        Process(
+          "docker buildx create --name multiple-arch-builder --use multi-arch-context",
+          baseDirectory.value
+        ).!
+      }
+    },
+    dockerBuildWithBuildx := {
+      streams.value.log("Building and pushing image with Buildx")
+      dockerAliases.value.foreach { alias =>
+        Process(
+          "docker buildx build --platform=linux/arm64,linux/amd64 --push -t " +
+            alias + " .",
+          baseDirectory.value / "target" / "docker" / "stage"
+        ).!
+      }
+    },
+    Docker / publish      := Def
+      .sequential(
+        Docker / publishLocal,
+        ensureDockerBuildx,
+        dockerBuildWithBuildx
+      )
+      .value
+  )
 }


### PR DESCRIPTION
Reverts sky-uk/kafka-message-scheduler#396

Broke publishing: 

```text
Multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
```