### PR TITLE
Simplify Topic Config and add tests

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,8 +46,9 @@ object Dependencies {
 
   object PureConfig {
     private val version = "0.17.8"
-    val core            = "com.github.pureconfig" %% "pureconfig-core"        % version
-    val catsEffect      = "com.github.pureconfig" %% "pureconfig-cats-effect" % version
+    val core            = "com.github.pureconfig" %% "pureconfig-core"           % version
+    val catsEffect      = "com.github.pureconfig" %% "pureconfig-cats-effect"    % version
+    val generic         = "com.github.pureconfig" %% "pureconfig-generic-scala3" % version
   }
 
   object OpenTelemetry {
@@ -113,6 +114,7 @@ object Dependencies {
     Otel4s.testkit,
     PureConfig.catsEffect,
     PureConfig.core,
+    PureConfig.generic,
     Vulcan.core,
     Vulcan.generic,
     chimney,

--- a/scheduler/src/main/scala/uk/sky/scheduler/EventSubscriber.scala
+++ b/scheduler/src/main/scala/uk/sky/scheduler/EventSubscriber.scala
@@ -34,7 +34,7 @@ object EventSubscriber {
 
     val avroConsumerSettings: ConsumerSettings[F, String, Either[ScheduleError, Option[AvroSchedule]]] = {
       given Resource[F, ValueDeserializer[F, Either[ScheduleError, Option[AvroSchedule]]]] = {
-        val scheduleDeserialzer: Resource[F, ValueDeserializer[F, Either[ScheduleError, Option[AvroSchedule]]]] =
+        val scheduleDeserializer: Resource[F, ValueDeserializer[F, Either[ScheduleError, Option[AvroSchedule]]]] =
           avroBinaryDeserializer[F, AvroSchedule].map(_.option.map(_.sequence))
         val scheduleWithoutHeadersDeserializer: Resource[
           F,
@@ -43,13 +43,14 @@ object EventSubscriber {
           avroBinaryDeserializer[F, AvroScheduleWithoutHeaders].map(_.option.map(_.sequence.map(_.map(_.avroSchedule))))
 
         for {
-          sDeserializer   <- scheduleDeserialzer
+          sDeserializer   <- scheduleDeserializer
           swhDeserializer <- scheduleWithoutHeadersDeserializer
         } yield sDeserializer.flatMap {
           case Right(maybeSchedule) =>
             GenericDeserializer
               .const[F, Either[ScheduleError, Option[AvroSchedule]]](Right(maybeSchedule))
-          case Left(_)              => swhDeserializer
+
+          case Left(_) => swhDeserializer
         }
       }
 
@@ -82,21 +83,15 @@ object EventSubscriber {
         }
 
       private val avroStream: Stream[F, ConsumerRecord[String, Either[ScheduleError, Option[AvroSchedule]]]] =
-        config.topics.avro
-          .flatMap(_.toNel)
+        config.topics.avro.toNel
           .fold(Stream.exec(avroLoadedRef.set(true) *> onLoadCompare(ExitCase.Succeeded)))(
-            TopicLoader.loadAndRun(_, avroConsumerSettings) { exitCase =>
-              avroLoadedRef.set(true) *> onLoadCompare(exitCase)
-            }
+            TopicLoader.loadAndRun(_, avroConsumerSettings)(avroLoadedRef.set(true) >> onLoadCompare(_))
           )
 
       private val jsonStream: Stream[F, ConsumerRecord[String, Either[ScheduleError, Option[JsonSchedule]]]] =
-        config.topics.json
-          .flatMap(_.toNel)
+        config.topics.json.toNel
           .fold(Stream.exec(jsonLoadedRef.set(true) *> onLoadCompare(ExitCase.Succeeded)))(
-            TopicLoader.loadAndRun(_, jsonConsumerSettings) { exitCase =>
-              jsonLoadedRef.set(true) *> onLoadCompare(exitCase)
-            }
+            TopicLoader.loadAndRun(_, jsonConsumerSettings)(jsonLoadedRef.set(true) >> onLoadCompare(_))
           )
 
       override def messages: Stream[F, Message[Output]] =
@@ -132,7 +127,7 @@ object EventSubscriber {
 
     for {
       counter <- Meter[F].counter[Long]("event-subscriber").create
-      logger   = LoggerFactory[F].getLogger
+      logger  <- LoggerFactory[F].create
     } yield new EventSubscriber[F] {
       override def messages: Stream[F, Message[Output]] =
         delegate.messages.evalTapChunk { case Message(key, source, value, metadata) =>

--- a/scheduler/src/test/scala/uk/sky/scheduler/config/TopicConfigSpec.scala
+++ b/scheduler/src/test/scala/uk/sky/scheduler/config/TopicConfigSpec.scala
@@ -1,0 +1,89 @@
+package uk.sky.scheduler.config
+
+import cats.data.NonEmptyList
+import cats.laws.discipline.arbitrary.*
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{EitherValues, LoneElement}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import pureconfig.ConfigSource
+
+final class TopicConfigSpec extends AnyWordSpec, ScalaCheckPropertyChecks, Matchers, EitherValues, LoneElement {
+
+  "TopicConfig.topicConfigReader" should {
+
+    extension (l: List[String]) {
+
+      /** List("a", "b") -> ["a", "b"]
+        */
+      private def toConfigString: String =
+        l.map(s => s""""$s"""").mkString("[", ", ", "]")
+    }
+
+    given arbValidConfigString: Arbitrary[String] = Arbitrary(Gen.alphaStr)
+
+    given arbConfig: Arbitrary[TopicConfig] = Arbitrary {
+      for {
+        avroTopics <- Arbitrary.arbitrary[NonEmptyList[String]]
+        jsonTopics <- Arbitrary.arbitrary[NonEmptyList[String]]
+      } yield TopicConfig(avro = avroTopics.toList, json = jsonTopics.toList)
+    }
+
+    "load when both Avro and JSON topics are non empty" in forAll { (topicConfig: TopicConfig) =>
+      val config = ConfigSource.string(
+        s"""
+           |{
+           |  avro: ${topicConfig.avro.toConfigString}
+           |  json: ${topicConfig.json.toConfigString}
+           |}
+           |""".stripMargin
+      )
+
+      config.load[TopicConfig].value shouldBe topicConfig
+    }
+
+    "load when only Avro topics are non empty" in forAll { (topicConfig: TopicConfig) =>
+      val config = ConfigSource.string(
+        s"""
+           |{
+           |  avro: ${topicConfig.avro.toConfigString}
+           |  json: []
+           |}
+           |""".stripMargin
+      )
+
+      config.load[TopicConfig].value shouldBe topicConfig.copy(json = List.empty)
+    }
+
+    "load when only JSON topics are non empty" in forAll { (topicConfig: TopicConfig) =>
+      val config = ConfigSource.string(
+        s"""
+           |{
+           |  avro: []
+           |  json: ${topicConfig.json.toConfigString}
+           |}
+           |""".stripMargin
+      )
+
+      config.load[TopicConfig].value shouldBe topicConfig.copy(avro = List.empty)
+    }
+
+    "error if both Avro and JSON topics are empty" in {
+      val config = ConfigSource.string(
+        s"""
+           |{
+           |  avro: []
+           |  json: []
+           |}
+           |""".stripMargin
+      )
+
+      config.load[TopicConfig].left.value.toList.loneElement.description should endWith(
+        "both Avro and JSON topics were empty"
+      )
+    }
+
+  }
+
+}


### PR DESCRIPTION
## Description

Update and add tests for TopicConfig

taken from https://github.com/sky-uk/kafka-message-scheduler/blob/fs2/scheduler/src/test/scala/uk/sky/scheduler/config/TopicConfigSpec.scala