### PR TITLE
Remove double chunk map on stream

### DIFF
--- a/scheduler/src/main/scala/uk/sky/scheduler/SchedulePublisher.scala
+++ b/scheduler/src/main/scala/uk/sky/scheduler/SchedulePublisher.scala
@@ -22,7 +22,7 @@ object SchedulePublisher {
       override def publish: Pipe[F, ScheduleEvent, Unit] = scheduleEventStream =>
         for {
           producer <- KafkaProducer.stream(producerSettings)
-          _        <- scheduleEventStream.chunks.evalMapChunk { scheduleEventChunk =>
+          _        <- scheduleEventStream.chunks.evalMap { scheduleEventChunk =>
                         val producerRecordChunk = scheduleEventChunk.flatMap(scheduleEvent =>
                           Chunk(scheduleEvent.toProducerRecord, scheduleEvent.toTombstone)
                         )


### PR DESCRIPTION
## Description

We are already calling `.chunks`, so calling `.evalMapChunk` is redundant