### PR TITLE
Add schema task to prBuild

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ val schema = inputKey[Unit]("Generate the Avro schema file for the Schedule sche
 lazy val avro = (project in file("avro"))
   .settings(scala3Settings)
   .settings(libraryDependencies ++= Dependencies.avro)
-  .settings(schema := (Compile / run).toTask("").value)
+  .settings(schema := (Compile / run).toTask(" --pretty-print").value)
   .settings(buildInfoSettings("uk.sky"))
   .dependsOn(scheduler)
 

--- a/project/Aliases.scala
+++ b/project/Aliases.scala
@@ -17,10 +17,11 @@ object Aliases {
 
   private def scalaPrBuild(module: String): List[String] =
     List(
-      "checkFix",
-      "checkFmt",
+      "checkLint",
       s"project $module",
       "test",
+      "project /",
+      "schema",
       "project it",
       "dockerComposeUp",
       "test",


### PR DESCRIPTION
Ensure it works; additionally add --pretty-print as a default flag.

As the avro module was converted to a CLI in https://github.com/sky-uk/kafka-message-scheduler/pull/399, it now accepts a `--pretty-print` flag to generate the Avro in prettified JSON. This was the original behaviour, and should be kept consistent. the output currently looks like:

```sbt
sbt schema
[info] Generated Schema file: .../kafka-message-scheduler/avro/target/schemas/schedule.avsc
```

```json
{
  "type" : "record",
  "name" : "AvroSchedule",
  "namespace" : "uk.sky.scheduler.kafka.avro",
  "fields" : [ {
    "name" : "time",
    "type" : "long",
    "doc" : "The time to execute the Schedule, in epoch milliseconds."
  }, {
    "name" : "topic",
    "type" : "string",
    "doc" : "The topic to send the Schedule to."
  }, {
    "name" : "key",
    "type" : "bytes",
    "doc" : "The key identifying the payload."
  }, {
    "name" : "value",
    "type" : [ "null", "bytes" ],
    "doc" : "The payload to be sent. null indicates a tombstone."
  }, {
    "name" : "headers",
    "type" : {
      "type" : "map",
      "values" : "bytes"
    },
    "doc" : "Optional extra metadata to send with the payload."
  } ]
}
```