### PR TITLE
Add default topics config to application.conf

### DIFF
--- a/scheduler/src/main/resources/application.conf
+++ b/scheduler/src/main/resources/application.conf
@@ -41,7 +41,7 @@ scheduler {
   }
 
   topics {
-    avro = []
-    json = []
+    avro = [${?SCHEDULE_TOPICS}]
+    json = [${?JSON_SCHEDULE_TOPICS}]
   }
 }

--- a/scheduler/src/main/resources/application.conf
+++ b/scheduler/src/main/resources/application.conf
@@ -39,4 +39,9 @@ scheduler {
       max-interval = 10 seconds
     }
   }
+
+  topics {
+    avro = []
+    json = []
+  }
 }


### PR DESCRIPTION
The service isn't able to start unless you specify both avro and json topics otherwise.

```
pureconfig.error.ConfigReaderException: Cannot convert configuration to a uk.sky.scheduler.config.Config. Failures are:  at 'scheduler.topics':    - (system properties) Key not found: 'json'.	at pureconfig.error.ConfigReaderException$.apply(ConfigReaderException.scala:9)	at pureconfig.module.catseffect.package$.loadF$$anonfun$3(package.scala:37)	at cats.data.EitherT.bimap$$anonfun$1(EitherT.scala:424)	at subflatMap @ pureconfig.module.catseffect.package$.loadF(package.scala:36)	at leftMap @ pureconfig.module.catseffect.package$.loadF(package.scala:37)	at rethrowT @ pureconfig.module.catseffect.package$.loadF(package.scala:38)	at flatMap @ uk.sky.scheduler.Main$.run$$anonfun$2$$anonfun$1$$anonfun$1$$anonfun$1(Main.scala:24)	at delay @ org.typelevel.otel4s.oteljava.metrics.MeterBuilderImpl.get(MeterBuilderImpl.scala:44)	at flatMap @ uk.sky.scheduler.Main$.run$$anonfun$2$$anonfun$1$$anonfun$1(Main.scala:23)	at apply @ org.typelevel.otel4s.context.LocalProvider$$anon$3.local(LocalProvider.scala:127)	at map @ org.typelevel.otel4s.context.LocalProvider$$anon$3.local(LocalProvider.scala:128)	at map @ org.typelevel.otel4s.oteljava.OtelJava$.forAsync(OtelJava.scala:68)	at delay @ org.typelevel.otel4s.oteljava.OtelJava$.global(OtelJava.scala:150)	at flatMap @ org.typelevel.otel4s.oteljava.OtelJava$.global(OtelJava.scala:150)	at flatMap @ uk.sky.scheduler.Main$.run$$anonfun$2$$anonfun$1(Main.scala:22)	at delay @ org.typelevel.log4cats.slf4j.Slf4jLogger$.fromName(Slf4jLogger.scala:45)	at flatMap @ uk.sky.scheduler.Main$.run$$anonfun$2(Main.scala:21)	at apply @ uk.sky.scheduler.Main$.run(Main.scala:20)
```