### PR TITLE
build: migrate to apache docker images

### DIFF
--- a/it/docker/docker-compose.yml
+++ b/it/docker/docker-compose.yml
@@ -24,27 +24,31 @@ services:
         condition: service_completed_successfully
 
   kafka:
-    image: bitnami/kafka:latest
+    image: apache/kafka:latest
     ports:
       - "9092:9092"
       - "9094:9094"
     environment:
-      KAFKA_CFG_NODE_ID: 0
-      KAFKA_CFG_PROCESS_ROLES: controller,broker
-      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
-      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@kafka:9093
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_NODE_ID: 0
+      KAFKA_PROCESS_ROLES: controller,broker
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 0@kafka:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
     healthcheck:
-      test: [ "CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list" ]
+      test: [ "CMD", "/opt/kafka/bin/kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list" ]
       interval: 5s
       timeout: 5s
       retries: 10
 
   # Create the input topics
   init-topics:
-    image: bitnami/kafka:latest
+    image: apache/kafka:latest
     depends_on:
       kafka:
         condition: service_healthy
@@ -52,8 +56,8 @@ services:
     command:
       - -c
       - >
-        kafka-topics.sh --create --if-not-exists --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1 --topic avro-schedules &&
-        kafka-topics.sh --create --if-not-exists --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1 --topic json-schedules
+        /opt/kafka/bin/kafka-topics.sh --create --if-not-exists --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1 --topic avro-schedules &&
+        /opt/kafka/bin/kafka-topics.sh --create --if-not-exists --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1 --topic json-schedules
 
 #  http://localhost:9090/ - Uncomment to expose Prometheus for local metrics testing.
 #  prometheus:
@@ -72,5 +76,5 @@ services:
 #    volumes:
 #      - ${PWD}/docker/akhq.yml:/app/application.yml
 #    depends_on:
-#      kafka:
-#        condition: service_healthy
+#      init-topics:
+#        condition: service_completed_successfully


### PR DESCRIPTION
# Docker Compose Migration: Bitnami Kafka → Apache Kafka

## Context

In August 2024, Bitnami (acquired by Broadcom) removed free access to their Docker images, including `bitnami/kafka:latest`. This required migrating the integration test Docker Compose setup to use the official Apache Kafka image.

**Official Announcement**: https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon

## Changes Made to `it/docker/docker-compose.yml`

### 1. Image Migration

**Before (Bitnami):**
```yaml
kafka:
  image: bitnami/kafka:latest
```

**After (Apache Kafka):**
```yaml
kafka:
  image: apache/kafka:latest
```

### 2. Environment Variable Prefix

Bitnami uses `KAFKA_CFG_*` prefix, Apache Kafka uses `KAFKA_*` directly.

**Before:**
```yaml
KAFKA_CFG_NODE_ID: 0
KAFKA_CFG_PROCESS_ROLES: controller,broker
KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
# etc.
```

**After:**
```yaml
KAFKA_NODE_ID: 0
KAFKA_PROCESS_ROLES: controller,broker
KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
# etc.
```

### 3. Script Paths

Bitnami has Kafka scripts in PATH, Apache Kafka requires full paths.

**Before:**
```yaml
healthcheck:
  test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]

command:
  - kafka-topics.sh --create --if-not-exists ...
```

**After:**
```yaml
healthcheck:
  test: ["CMD", "/opt/kafka/bin/kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]

command:
  - /opt/kafka/bin/kafka-topics.sh --create --if-not-exists ...
```

### 4. Critical Configuration for Testing (THE FIX)

Added essential Apache Kafka settings for single-node test environments:

```yaml
KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
```

**Key Setting**: `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0` was the critical fix. Without this, consumer groups wait for a delay before performing the initial rebalance, causing integration tests to timeout waiting for messages.

The other three settings are required for single-node Kafka deployments (defaults expect 3 brokers).

## Troubleshooting Notes

### Initial Issue
Integration tests failed with:
```
Could not consume 1 messages within 30 seconds
```

### Debugging Steps
1. ✅ Verified KMS produces messages successfully
2. ✅ Verified messages exist in topics (using kcat)
3. ✅ Verified admin client can connect
4. ❌ Consumer timed out after 30 seconds

### Root Cause
The Apache Kafka Docker image has different defaults than Bitnami. Specifically, `group.initial.rebalance.delay.ms` defaults to 3000ms (3 seconds) in production Kafka, but the Apache Kafka Docker documentation recommends setting it to 0 for test/development environments to avoid delays in consumer group coordination.

### Solution
Added the four configuration settings listed above, as recommended in the official Apache Kafka Docker documentation.

## References

- **Apache Kafka Docker Docs**: https://hub.docker.com/r/apache/kafka
- **Bitnami Deprecation Announcement**: https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon
- **Apache Kafka Docker Usage Guide**: Recommends `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0` for test environments

