### PR TITLE
feat: dedupe consumer messages by key within chunks

### DIFF
--- a/scheduler/src/main/scala/uk/sky/scheduler/Scheduler.scala
+++ b/scheduler/src/main/scala/uk/sky/scheduler/Scheduler.scala
@@ -4,6 +4,7 @@ import cats.Parallel
 import cats.effect.*
 import cats.effect.std.Supervisor
 import cats.effect.syntax.all.*
+import cats.syntax.all.*
 import fs2.Stream
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.otel4s.metrics.Meter
@@ -12,19 +13,23 @@ import uk.sky.scheduler.core.ResourceReader
 import uk.sky.scheduler.domain.ScheduleEvent
 import uk.sky.scheduler.message.Message
 import uk.sky.scheduler.message.Metadata.*
+import uk.sky.scheduler.syntax.all.*
 
 class Scheduler[F[_] : Concurrent, O](
     eventSubscriber: EventSubscriber[F],
     scheduleQueue: ScheduleQueue[F],
     schedulePublisher: SchedulePublisher[F, O]
 ) {
-  private val scheduleEvents = eventSubscriber.messages.evalTapChunk { case Message(key, _, value, metadata) =>
-    value match {
-      case Left(_)               => scheduleQueue.cancel(key)
-      case Right(None)           => Concurrent[F].unlessA(metadata.isExpired)(scheduleQueue.cancel(key))
-      case Right(Some(schedule)) => scheduleQueue.schedule(key, schedule)
-    }
-  }
+  private val scheduleEvents =
+    eventSubscriber.messages
+      .mapChunks(_.dedupeBy(_.key))
+      .evalTapChunk { case Message(key, _, value, metadata) =>
+        value match {
+          case Left(_)               => scheduleQueue.cancel(key)
+          case Right(None)           => scheduleQueue.cancel(key).unlessA(metadata.isExpired)
+          case Right(Some(schedule)) => scheduleQueue.schedule(key, schedule)
+        }
+      }
 
   def stream: Stream[F, O] =
     scheduleEvents.drain

--- a/scheduler/src/main/scala/uk/sky/scheduler/syntax/ChunkSyntax.scala
+++ b/scheduler/src/main/scala/uk/sky/scheduler/syntax/ChunkSyntax.scala
@@ -1,0 +1,29 @@
+package uk.sky.scheduler.syntax
+
+import fs2.Chunk
+
+import scala.collection.mutable
+
+trait ChunkSyntax {
+  extension [A](chunk: Chunk[A]) {
+
+    /** Deduplicates elements in the chunk by a key function, keeping the latest value for each key.
+      *
+      * Preserves the insertion order of the first occurrence of each key.
+      *
+      * @param key
+      *   function to extract the deduplication key from each element
+      * @tparam K
+      *   the type of the deduplication key
+      * @return
+      *   a new chunk with duplicates removed
+      */
+    def dedupeBy[K](key: A => K): Chunk[A] = {
+      val seen = mutable.LinkedHashMap.empty[K, A]
+      chunk.foreach(a => seen.update(key(a), a))
+      Chunk.from(seen.values)
+    }
+  }
+}
+
+object chunk extends ChunkSyntax

--- a/scheduler/src/main/scala/uk/sky/scheduler/syntax/all.scala
+++ b/scheduler/src/main/scala/uk/sky/scheduler/syntax/all.scala
@@ -1,3 +1,3 @@
 package uk.sky.scheduler.syntax
 
-object all extends ClockSyntax
+object all extends ChunkSyntax, ClockSyntax

--- a/scheduler/src/test/scala/uk/sky/scheduler/syntax/ChunkSyntaxSpec.scala
+++ b/scheduler/src/test/scala/uk/sky/scheduler/syntax/ChunkSyntaxSpec.scala
@@ -1,0 +1,56 @@
+package uk.sky.scheduler.syntax
+
+import fs2.Chunk
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ChunkSyntaxSpec extends AnyWordSpec, Matchers, ChunkSyntax {
+
+  "ChunkSyntax" when {
+    "dedupeBy" should {
+      final case class Item(id: Int, value: String)
+
+      "return empty chunk when input is empty" in {
+        val chunk = Chunk.empty[Item]
+        chunk.dedupeBy(_.id).toList shouldBe empty
+      }
+
+      "return same chunk when all elements have unique keys" in {
+        val chunk = Chunk(
+          Item(1, "a"),
+          Item(2, "b"),
+          Item(3, "c")
+        )
+        chunk.dedupeBy(_.id).toList should contain theSameElementsInOrderAs List(
+          Item(1, "a"),
+          Item(2, "b"),
+          Item(3, "c")
+        )
+      }
+
+      "keep latest value and preserve insertion order" in {
+        val chunk = Chunk(
+          Item(1, "a"),
+          Item(2, "b"),
+          Item(3, "c"),
+          Item(1, "a-updated"),
+          Item(2, "b-updated")
+        )
+        chunk.dedupeBy(_.id).toList should contain theSameElementsInOrderAs List(
+          Item(1, "a-updated"),
+          Item(2, "b-updated"),
+          Item(3, "c")
+        )
+      }
+
+      "keep latest value when all elements have same key" in {
+        val chunk = Chunk(
+          Item(1, "first"),
+          Item(1, "second"),
+          Item(1, "third")
+        )
+        chunk.dedupeBy(_.id).toList should contain theSameElementsInOrderAs List(Item(1, "third"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Often in Kafka we read in a bunch of messages in a single poll (defaults to 500 in Java Consumer). In fs2-kafka this is a chunk of messages, where our business logic may not care about duplicate keys within that chunk, and we can just process the last one in. This PR adds a `dedupeBy` method to the Chunk syntax, to allow de-duping items in a chunk by a key function.