### PR TITLE
bug: Repository metrics are reversed

### DIFF
--- a/scheduler/src/main/scala/uk/sky/scheduler/Repository.scala
+++ b/scheduler/src/main/scala/uk/sky/scheduler/Repository.scala
@@ -50,8 +50,8 @@ object Repository {
           underlying
             .set(key, value)
             .flatMap {
-              case Some(_) => counter.inc(RepositoryAttribute.Total) &> counter.inc(RepositoryAttribute.Set)
-              case None    => Monad[F].unit
+              case Some(_) => counter.inc(RepositoryAttribute.Set)
+              case None    => counter.inc(RepositoryAttribute.Total) &> counter.inc(RepositoryAttribute.Set)
             }
 
         override def get(key: K): F[Option[V]] =
@@ -66,8 +66,8 @@ object Repository {
           underlying
             .delete(key)
             .flatMap {
-              case Some(_) => Monad[F].unit
-              case None    => counter.dec(RepositoryAttribute.Total) &> counter.inc(RepositoryAttribute.Delete)
+              case Some(_) => counter.dec(RepositoryAttribute.Total) &> counter.inc(RepositoryAttribute.Delete)
+              case None    => Monad[F].unit
             }
       }
     }


### PR DESCRIPTION
## Description

The counters for `set` and `delete` were reversed. 

For Set:

- New key (None) adds to the total
- Existing key just increments Set attribute

For Delete:

- Key existing means we actually deleted it
- None should do nothing